### PR TITLE
helm chart가 terraform destroy 시 정상적으로 삭제되지 않는 문제 해결.

### DIFF
--- a/basic_kubernetes_cluster/main.tf
+++ b/basic_kubernetes_cluster/main.tf
@@ -228,8 +228,6 @@ resource "helm_release" "kube-prometheus-stack" {
     value = "/monitor"
   }
 
-
-
   set {
     name  = "prometheus-node-exporter.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key"
     value = "eks.amazonaws.com/compute-type"
@@ -244,4 +242,6 @@ resource "helm_release" "kube-prometheus-stack" {
     name  = "prometheus-node-exporter.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]"
     value = "fargate"
   }
+  
+  depends_on = [ module.eks ]
 }


### PR DESCRIPTION
depends_on = [module.eks]를 추가하는 것으로 해결.