### PR TITLE
basic kubernetes cluster 생성 후, update-kubeconfig를 별도로 수행하지 않아도 되도록 수정

### DIFF
--- a/basic_kubernetes_cluster/main.tf
+++ b/basic_kubernetes_cluster/main.tf
@@ -245,3 +245,15 @@ resource "helm_release" "kube-prometheus-stack" {
   
   depends_on = [ module.eks ]
 }
+
+resource "null_resource" "update-kubeconfig" {
+  triggers = {
+    cluster_name = module.eks.cluster_name
+  }
+  provisioner "local-exec" {
+    when = create
+    command = "aws eks update-kubeconfig --name ${var.cluster_name} --profile ${var.awscli_profile} --region ${var.region}"
+  }
+
+  depends_on = [ module.eks ]
+}

--- a/basic_kubernetes_cluster/main.tf
+++ b/basic_kubernetes_cluster/main.tf
@@ -243,7 +243,7 @@ resource "helm_release" "kube-prometheus-stack" {
     value = "fargate"
   }
   
-  depends_on = [ module.eks ]
+  depends_on = [ module.eks, helm_release.aws-load-balancer-controller ]
 }
 
 resource "null_resource" "update-kubeconfig" {


### PR DESCRIPTION
제곧내
이제 바로 kubectl 사용가능합니다. (kubectl이 설치되어있다는 전제)