### PR TITLE
API IaC 코드 추가 / 수정

### DIFF
--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -20,6 +20,42 @@ resource "aws_iam_role_policy_attachment" "lambda_basic_policy" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+resource "aws_iam_role_policy_attachment" "cloudwatch_policy" {
+  count = var.attach_cloudwatch_policy
+  role       = aws_iam_role.lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/CloudWatchFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatchlogs_policy" {
+  count = var.attach_cloudwatch_policy
+  role       = aws_iam_role.lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/CloudWatchLogsFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_policy" {
+  count = var.attach_ec2_policy
+  role       = aws_iam_role.lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_policy" {
+  count = var.attach_vpc_policy
+  role       = aws_iam_role.lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonVPCFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "s3_policy" {
+  count = var.attach_s3_policy
+  role       = aws_iam_role.lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonS3FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_policy" {
+  count = var.attach_lambda_policy
+  role       = aws_iam_role.lambda-role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambda_FullAccess"
+}
+
 resource "aws_lambda_function" "lambda" {
   function_name = "${var.prefix}-aws-lambda"
   package_type  = "Image"

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -3,3 +3,8 @@ variable "container_registry" {}
 variable "container_repository" {}
 variable "container_image_tag" {}
 variable "ram_mib" {}
+variable "attach_cloudwatch_policy" {}
+variable "attach_ec2_policy" {}
+variable "attach_lambda_policy" {}
+variable "attach_s3_policy" {}
+variable "attach_vpc_policy" {}

--- a/IaC/serverless_api_template/var.tf
+++ b/IaC/serverless_api_template/var.tf
@@ -32,3 +32,28 @@ variable "lambda_ram_size" {
   type    = number
   default = 2048
 }
+
+variable "attach_ec2_policy" {
+  type = bool
+  default = false
+}
+
+variable "attach_s3_policy" {
+  type = bool
+  default = false
+}
+
+variable "attach_vpc_policy" {
+  type = bool
+  default = false
+}
+
+variable "attach_lambda_policy" {
+  type = bool
+  default = false
+}
+
+variable "attach_cloudwatch_policy" {
+  type = bool
+  default = false
+}

--- a/automation/serverless_inference_deploy/IaC/main.tf
+++ b/automation/serverless_inference_deploy/IaC/main.tf
@@ -1,0 +1,41 @@
+
+module "serverless_inference_deploy" {
+  source = "github.com/kookmin-sw/capstone-2024-12//IaC/serverless_api_template"
+  prefix = "cpu_family_recommend"
+  container_registry = "694448341573.dkr.ecr.ap-northeast-2.amazonaws.com"
+  container_repository = "recommend-inference-cpu-family"
+  container_image_tag = "latest"
+  lambda_ram_size = 2048
+  attach_s3_policy = true
+  attach_ec2_policy = true
+  attach_lambda_policy = true
+  attach_cloudwatch_policy = true
+}
+
+variable "region" {
+  type    = string
+  default = "ap-northeast-2"
+}
+
+variable "awscli_profile" {
+  type    = string
+  default = "default"
+}
+
+output "function_url" {
+  value = module.serverless_inference.function_url
+}
+
+provider "aws" {
+    region = var.region
+    profile = var.awscli_profile
+}
+
+terraform {
+  backend "s3" {
+    bucket = "sskai-terraform-state"
+    key = "family_recommend/tf.state"
+    region = "ap-northeast-2"
+    encrypt = true
+  }
+}

--- a/automation/serverless_inference_deploy/IaC/main.tf
+++ b/automation/serverless_inference_deploy/IaC/main.tf
@@ -1,9 +1,9 @@
 
 module "serverless_inference_deploy" {
   source = "github.com/kookmin-sw/capstone-2024-12//IaC/serverless_api_template"
-  prefix = "cpu_family_recommend"
+  prefix = "serverless_inference_deploy"
   container_registry = "694448341573.dkr.ecr.ap-northeast-2.amazonaws.com"
-  container_repository = "recommend-inference-cpu-family"
+  container_repository = "serverless-inference-deploy"
   container_image_tag = "latest"
   lambda_ram_size = 2048
   attach_s3_policy = true

--- a/automation/serverless_inference_deploy/IaC/main.tf
+++ b/automation/serverless_inference_deploy/IaC/main.tf
@@ -34,7 +34,7 @@ provider "aws" {
 terraform {
   backend "s3" {
     bucket = "sskai-terraform-state"
-    key = "family_recommend/tf.state"
+    key = "serverless_inference_deploy/tf.state"
     region = "ap-northeast-2"
     encrypt = true
   }

--- a/recommend/family_recommend/IaC/main.tf
+++ b/recommend/family_recommend/IaC/main.tf
@@ -1,0 +1,54 @@
+
+module "cpu_family_recommend" {
+  source = "github.com/kookmin-sw/capstone-2024-12//IaC/serverless_api_template"
+  prefix = "cpu_family_recommend"
+  container_registry = "694448341573.dkr.ecr.ap-northeast-2.amazonaws.com"
+  container_repository = "recommend-inference-cpu-family"
+  container_image_tag = "latest"
+  lambda_ram_size = 2048
+  attach_s3_policy = true
+  attach_ec2_policy = true
+}
+
+module "gpu_family_recommend" {
+  source = "github.com/kookmin-sw/capstone-2024-12//IaC/serverless_api_template"
+  prefix = "gpu_family_recommend"
+  container_registry = "694448341573.dkr.ecr.ap-northeast-2.amazonaws.com"
+  container_repository = "recommend-inference-gpu-family"
+  container_image_tag = "latest"
+  lambda_ram_size = 2048
+  attach_s3_policy = true
+  attach_ec2_policy = true
+}
+
+variable "region" {
+  type    = string
+  default = "ap-northeast-2"
+}
+
+variable "awscli_profile" {
+  type    = string
+  default = "default"
+}
+
+output "cpu_recommend_function_url" {
+  value = module.cpu_family_recommend.function_url
+}
+
+output "gpu_recommend_function_url" {
+  value = module.gpu_family_recommend.function_url
+}
+
+provider "aws" {
+    region = var.region
+    profile = var.awscli_profile
+}
+
+terraform {
+  backend "s3" {
+    bucket = "sskai-terraform-state"
+    key = "family_recommend/tf.state"
+    region = "ap-northeast-2"
+    encrypt = true
+  }
+}


### PR DESCRIPTION
2가지 API에 대한 IaC 코드를 추가 및 수정합니다.
- Serverless Inference Terraform을 배포하는 Lambda IaC 수정
  - 이 API는 여러번 배포할 것이 아니기 떄문에 bucket에 tfstate를 저장하도록 변경
- Instance Family 추천 API 배포 IaC 추가
  - 이도 마찬가지로 terraform state bucket을 사용해서 state를 관리하도록 수정.

---

앞으로 모든 API는 serverless_api_template module을 사용하여 배포할 예정이며, 필요한 권한이 추가되는 경우 serverless_api_template module을 수정하는 방향으로 진행될 예정입니다. (코드 재사용)

---

@jhM00n 기존 ECR삭제하고 ECR Repo Name을 serverless-inference-deploy로 변경바랍니다.