### PR TITLE
Dockfile에 aws terraform module을 사용하도록 추가

### DIFF
--- a/automation/serverless_inference_deploy/Dockerfile
+++ b/automation/serverless_inference_deploy/Dockerfile
@@ -1,9 +1,10 @@
 FROM public.ecr.aws/lambda/python:3.12
 
-COPY lambda.py ${LAMBDA_TASK_ROOT}
+COPY ./lambda.py ${LAMBDA_TASK_ROOT}
 COPY ./terraform ${LAMBDA_TASK_ROOT}
+COPY ./terraform-provider-aws_v5.43.0_x5 ${LAMBDA_TASK_ROOT}
+COPY ./.terraform.lock.hcl ${LAMBDA_TASK_ROOT}
 
-ENV PATH="/var/task:${PATH}"
 
 RUN chmod +x /var/task
 RUN dnf install git -y

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -4,6 +4,16 @@ import boto3
 import json
 import uuid
 
+# terraform module 설정
+local_dir = '/tmp'
+os.chdir(local_dir)
+
+subprocess.run(["mkdir","-p",".terraform/providers/registry.terraform.io/hashicorp/aws/5.43.0/linux_amd64"])
+os.chdir('.terraform/providers/registry.terraform.io/hashicorp/aws/5.43.0/linux_amd64')
+subprocess.run(["ln", "-s", "/var/task/terraform-provider-aws_v5.43.0_x5"])
+os.chdir(local_dir)
+subprocess.run(["ln", "-s", "/var/task/.terraform.lock.hcl"])
+
 def download_s3_folder(bucket_name, s3_folder, local_dir):
     s3 = boto3.client('s3')
     paginator = s3.get_paginator('list_objects_v2')
@@ -43,7 +53,6 @@ def handler(event, context):
 
     bucket_name = 'skkai-lambda-test'
     s3_folder = 'lambda-IaC_test/'
-    local_dir = '/tmp'
 
     download_s3_folder(bucket_name, s3_folder, local_dir)
 
@@ -53,9 +62,6 @@ def handler(event, context):
 
     # Terraform 바이너리의 전체 경로 설정
     terraform_binary = '/var/task/terraform'
-
-    # 작업 디렉토리를 /tmp로 변경
-    os.chdir(local_dir)
 
     # backend 생성
     create_backend(username, model_name, hash)

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -9,9 +9,7 @@ local_dir = '/tmp'
 os.chdir(local_dir)
 
 subprocess.run(["mkdir","-p",".terraform/providers/registry.terraform.io/hashicorp/aws/5.43.0/linux_amd64"])
-os.chdir('.terraform/providers/registry.terraform.io/hashicorp/aws/5.43.0/linux_amd64')
-subprocess.run(["ln", "-s", "/var/task/terraform-provider-aws_v5.43.0_x5"])
-os.chdir(local_dir)
+subprocess.run(["ln", "-s", "/var/task/terraform-provider-aws_v5.43.0_x5", ".terraform/providers/registry.terraform.io/hashicorp/aws/5.43.0/linux_amd64"])
 subprocess.run(["ln", "-s", "/var/task/.terraform.lock.hcl"])
 
 def download_s3_folder(bucket_name, s3_folder, local_dir):


### PR DESCRIPTION
처음 terraform init시 aws terraform module을 다운로드 받는데, 용량이 434.5MB로 오랜 시간이 걸려 dockerfile에 넣어 시간을 줄이도록 함.

aws terraform module은 skkai-lambda-test 이름의 s3 버킷에 업로드 해놓았음.

aws terraform module은 v5.43.0, amd64임.