### PR TITLE
terraform 생성 및 삭제에 따라 endpoint url을 db에 등록 및 삭제 하도록 변경

### DIFF
--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -75,7 +75,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       EKS_CLUSTER_NAME = var.eks_cluster_name
       RECOMMEND_BUCKET_NAME = var.recommend_bucket_name
-      INFERENCE_URL = var.inference_url
+      INFERENCE_URL = var.db_api_url
     }
   }
 }

--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -75,6 +75,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       EKS_CLUSTER_NAME = var.eks_cluster_name
       RECOMMEND_BUCKET_NAME = var.recommend_bucket_name
+      ECR_URI_NAME = var.ecr_uri_name
     }
   }
 }

--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -75,8 +75,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       EKS_CLUSTER_NAME = var.eks_cluster_name
       RECOMMEND_BUCKET_NAME = var.recommend_bucket_name
-      ADD_INFERENCE_URL = var.add_inference_url
-      DELETE_INFERENCE_URL = var.delete_inference_url
+      INFERENCE_URL = var.inference_url
     }
   }
 }

--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -76,6 +76,7 @@ resource "aws_lambda_function" "lambda" {
       EKS_CLUSTER_NAME = var.eks_cluster_name
       RECOMMEND_BUCKET_NAME = var.recommend_bucket_name
       DB_API_URL = var.db_api_url
+      STATE_BUCKET_NAME = var.state_bucket_name
     }
   }
 }

--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -75,7 +75,8 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       EKS_CLUSTER_NAME = var.eks_cluster_name
       RECOMMEND_BUCKET_NAME = var.recommend_bucket_name
-      ECR_URI_NAME = var.ecr_uri_name
+      ADD_INFERENCE_URL = var.add_inference_url
+      DELETE_INFERENCE_URL = var.delete_inference_url
     }
   }
 }

--- a/IaC/serverless_api_template/lambda/main.tf
+++ b/IaC/serverless_api_template/lambda/main.tf
@@ -75,7 +75,7 @@ resource "aws_lambda_function" "lambda" {
     variables = {
       EKS_CLUSTER_NAME = var.eks_cluster_name
       RECOMMEND_BUCKET_NAME = var.recommend_bucket_name
-      INFERENCE_URL = var.db_api_url
+      DB_API_URL = var.db_api_url
     }
   }
 }

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -11,5 +11,7 @@ variable "attach_s3_policy" {}
 variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
-variable "add_inference_url" {}
-variable "delete_inference_url" {}
+variable "inference_url" {
+    type = string
+    default = "https://wpcwvjlvkl.execute-api.ap-northeast-2.amazonaws.com/sskai-api-dev/inferences"
+}

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -11,3 +11,4 @@ variable "attach_s3_policy" {}
 variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
+variable "ecr_uri_name" {}

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -12,3 +12,4 @@ variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
 variable "db_api_url" {}
+variable "terraform_state_bucket_name" {}

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -11,4 +11,4 @@ variable "attach_s3_policy" {}
 variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
-variable "inference_url" {}
+variable "db_api_url" {}

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -12,4 +12,4 @@ variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
 variable "db_api_url" {}
-variable "terraform_state_bucket_name" {}
+variable "state_bucket_name" {}

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -11,4 +11,5 @@ variable "attach_s3_policy" {}
 variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
-variable "ecr_uri_name" {}
+variable "add_inference_url" {}
+variable "delete_inference_url" {}

--- a/IaC/serverless_api_template/lambda/var.tf
+++ b/IaC/serverless_api_template/lambda/var.tf
@@ -11,7 +11,4 @@ variable "attach_s3_policy" {}
 variable "attach_vpc_policy" {}
 variable "attach_eks_policy" {}
 variable "recommend_bucket_name" {}
-variable "inference_url" {
-    type = string
-    default = "https://wpcwvjlvkl.execute-api.ap-northeast-2.amazonaws.com/sskai-api-dev/inferences"
-}
+variable "inference_url" {}

--- a/automation/serverless_inference_deploy/.gitignore
+++ b/automation/serverless_inference_deploy/.gitignore
@@ -1,2 +1,5 @@
 # Terraform binary
 terraform
+
+# aws ecr login
+push_aws_ecr.sh

--- a/automation/serverless_inference_deploy/Dockerfile
+++ b/automation/serverless_inference_deploy/Dockerfile
@@ -9,5 +9,6 @@ COPY ./main.tf ${LAMBDA_TASK_ROOT}
 RUN chmod +x /var/task
 RUN dnf install git -y
 RUN dnf clean all
+RUN pip install requests
 
 CMD ["lambda.handler"]

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -50,7 +50,7 @@ def handler(event, context):
         if action == 'destroy':
             subprocess.run([terraform_binary, "destroy", "-auto-approve"])
             
-            delete_inference_url = "https://wpcwvjlvkl.execute-api.ap-northeast-2.amazonaws.com/sskai-api-dev/inferences/"+inference_uid
+            delete_inference_url = "[실제 url 입력]"+inference_uid
             response = requests.delete(delete_inference_url)
 
             return {
@@ -87,7 +87,7 @@ def handler(event, context):
                 "endpoint": endpoint_url
             }
 
-            add_inference_url="https://wpcwvjlvkl.execute-api.ap-northeast-2.amazonaws.com/sskai-api-dev/inferences"
+            add_inference_url="[실제 url 입력]"
             response = requests.post(add_inference_url, json=add_inferences)
 
             return {

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -1,8 +1,10 @@
 import subprocess
 import os
-import boto3
 import json
-import uuid
+import requests
+
+# Terraform 바이너리의 전체 경로 설정
+terraform_binary = '/var/task/terraform'
 
 # terraform module 설정
 local_dir = '/tmp'
@@ -13,13 +15,13 @@ subprocess.run(["ln", "-s", "/var/task/terraform-provider-aws_v5.43.0_x5", ".ter
 subprocess.run(["ln", "-s", "/var/task/.terraform.lock.hcl"])
 subprocess.run(["ln", "-s", "/var/task/main.tf", "/tmp"])
 
-def create_backend(username, model, hash):
+def create_backend(user_uid, type, model_uid, endpoint_name):
 # Terraform backend 생성
     terraform_backend = f"""
     terraform {{
     backend "s3" {{
         bucket = "sskai-terraform-state"
-        key = "serverless_inference/{username}/{model}/{hash}/terraform.state"
+        key = "{user_uid}/{model_uid}/{type}/{endpoint_name}/terraform.state"
         region = "ap-northeast-2"
         encrypt = true
     }}
@@ -31,47 +33,70 @@ def create_backend(username, model, hash):
         f.write(terraform_backend)
 
 def handler(event, context):
-
-    endpoint_name = event["queryStringParameters"]["ENDPOINT_NAME"]
-    type = event["queryStringParameters"]["TYPE"]
-    username = event["queryStringParameters"]["USERNAME"]
-    action = event["queryStringParameters"]["ACTION"]
-    container_registry = event["queryStringParameters"]["CONTAINER_REGISTRY"]
-    model_name = event["queryStringParameters"]["MODEL_NAME"]
-    
-    # hash 생성
-    # hash = str(uuid.uuid4())
-    hash = 1234
-
-    # Terraform 바이너리의 전체 경로 설정
-    terraform_binary = '/var/task/terraform'
+    params = event.get("queryStringParameters", {})
+    user_uid = params.get("USER_UID")
+    endpoint_name = params.get("ENDPOINT_NAME")
+    model_uid = params.get("MODEL_UID")
+    type = params.get("TYPE")
+    action = params.get("ACTION")
 
     # backend 생성
-    create_backend(username, model_name, hash)
+    create_backend(user_uid, type, model_uid, endpoint_name)
 
-    # Terraform init
-    subprocess.run([terraform_binary, "init", "-reconfigure"])
+    inference_uid = params.get("INFERENCE_UID")
 
-    # Terraform apply
-    if action == 'create':
-        subprocess.run([terraform_binary, "apply", "-auto-approve"])
+    if inference_uid:        
+        # Terraform destroy
+        if action == 'destroy':
+            subprocess.run([terraform_binary, "destroy", "-auto-approve"])
+            
+            delete_inference_url = "https://wpcwvjlvkl.execute-api.ap-northeast-2.amazonaws.com/sskai-api-dev/inferences/"+inference_uid
+            response = requests.delete(delete_inference_url)
+
+            return {
+            'statusCode': 200,
+            'body': 'Terraform Destroyed Successfully'
+            }
         
-        # Terraform 출력값 가져오기
-        output = subprocess.check_output([terraform_binary, "output", "-json"])
-        outputs = json.loads(output.decode('utf-8'))
+        else:
+            return{
+                'statusCode': 201,
+                'body': 'Please check the action'
+            }
+        
+    else:        
+        # Terraform init
+        subprocess.run([terraform_binary, "init", "-reconfigure"])
 
-        # 'function_url' 출력값 추출
-        endpoint_url = outputs['function_url']['value']
+        # Terraform apply
+        if action == 'create':
+            subprocess.run([terraform_binary, "apply", "-auto-approve"])
+            
+            # Terraform 출력값 가져오기
+            output = subprocess.check_output([terraform_binary, "output", "-json"])
+            outputs = json.loads(output.decode('utf-8'))
 
-        return {
-        'statusCode': 200,
-        'body': f'Endpoint URL: {endpoint_url}'
-        }
-    
-    # Terraform destroy
-    if action == 'destroy':
-        subprocess.run([terraform_binary, "destroy", "-auto-approve"])
-        return {
-        'statusCode': 200,
-        'body': 'Terraform Destroyed Successfully'
-        }
+            # 'function_url' 출력값 추출
+            endpoint_url = outputs['function_url']['value']
+
+            add_inferences = {
+                "user": user_uid,
+                "name": endpoint_name,
+                "model": model_uid,
+                "type": type,
+                "endpoint": endpoint_url
+            }
+
+            add_inference_url="https://wpcwvjlvkl.execute-api.ap-northeast-2.amazonaws.com/sskai-api-dev/inferences"
+            response = requests.post(add_inference_url, json=add_inferences)
+
+            return {
+            'statusCode': 200,
+            'body': f'Endpoint URL: {endpoint_url}'
+            }
+        
+        else:
+            return {
+                'statusCode': 201,
+                'body': 'Please check the action'
+            }

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -53,7 +53,7 @@ def handler(event, context):
         if action == 'destroy':
             subprocess.run([terraform_binary, "destroy", "-auto-approve"])
             
-            delete_inference_url = "[실제 url 입력]"+inference_uid
+            delete_inference_url = os.getenv("DELETE_INFERENCE_URL")+inference_uid
             response = requests.delete(delete_inference_url)
 
             return {
@@ -87,7 +87,7 @@ def handler(event, context):
                 "endpoint": endpoint_url
             }
 
-            add_inference_url="[실제 url 입력]"
+            add_inference_url= os.getenv("ADD_INFERENCE_URL")
             response = requests.post(add_inference_url, json=add_inferences)
 
             return {

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -53,7 +53,7 @@ def handler(event, context):
         if action == 'destroy':
             subprocess.run([terraform_binary, "destroy", "-auto-approve"])
             
-            delete_inference_url = os.getenv("DELETE_INFERENCE_URL")+inference_uid
+            delete_inference_url = os.getenv("INFERENCE_URL")+"/"+inference_uid
             response = requests.delete(delete_inference_url)
 
             return {
@@ -87,7 +87,7 @@ def handler(event, context):
                 "endpoint": endpoint_url
             }
 
-            add_inference_url= os.getenv("ADD_INFERENCE_URL")
+            add_inference_url= os.getenv("INFERENCE_URL")
             response = requests.post(add_inference_url, json=add_inferences)
 
             return {

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -87,7 +87,7 @@ def handler(event, context):
                 "endpoint": endpoint_url
             }
 
-            add_inference_url= os.getenv("INFERENCE_URL")
+            add_inference_url= "https://"+os.getenv("INFERENCE_URL")
             response = requests.post(add_inference_url, json=add_inferences)
 
             return {

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -17,7 +17,7 @@ subprocess.run(["ln", "-s", "/var/task/main.tf", "/tmp"])
 
 def create_backend(user_uid, type, model_uid, endpoint_name):
 # Terraform backend 생성
-    bucket_name = os.getenv("TERRAFORM_STATE_BUCKET_NAME")
+    bucket_name = os.getenv("STATE_BUCKET_NAME")
     terraform_backend = f"""
     terraform {{
     backend "s3" {{
@@ -54,7 +54,7 @@ def handler(event, context):
         if action == 'destroy':
             subprocess.run([terraform_binary, "destroy", "-auto-approve"])
             
-            delete_inference_url = "https://"+os.getenv("DB_API_URL")+"/"+inference_uid
+            delete_inference_url = "https://"+os.getenv("DB_API_URL")+"/sskai-api-dev/inferences/"+inference_uid
             response = requests.delete(delete_inference_url)
 
             return {
@@ -88,7 +88,7 @@ def handler(event, context):
                 "endpoint": endpoint_url
             }
 
-            add_inference_url= "https://"+os.getenv("DB_API_URL")
+            add_inference_url= "https://"+os.getenv("DB_API_URL")+"/sskai-api-dev/inferences"
             response = requests.post(add_inference_url, json=add_inferences)
 
             return {

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -17,10 +17,11 @@ subprocess.run(["ln", "-s", "/var/task/main.tf", "/tmp"])
 
 def create_backend(user_uid, type, model_uid, endpoint_name):
 # Terraform backend 생성
+    bucket_name = os.getenv("TERRAFORM_STATE_BUCKET_NAME")
     terraform_backend = f"""
     terraform {{
     backend "s3" {{
-        bucket = "sskai-terraform-state"
+        bucket = "{bucket_name}"
         key = "{user_uid}/{model_uid}/{type}/{endpoint_name}/terraform.state"
         region = "ap-northeast-2"
         encrypt = true

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -53,7 +53,7 @@ def handler(event, context):
         if action == 'destroy':
             subprocess.run([terraform_binary, "destroy", "-auto-approve"])
             
-            delete_inference_url = os.getenv("INFERENCE_URL")+"/"+inference_uid
+            delete_inference_url = "https://"+os.getenv("DB_API_URL")+"/"+inference_uid
             response = requests.delete(delete_inference_url)
 
             return {

--- a/automation/serverless_inference_deploy/lambda.py
+++ b/automation/serverless_inference_deploy/lambda.py
@@ -87,7 +87,7 @@ def handler(event, context):
                 "endpoint": endpoint_url
             }
 
-            add_inference_url= "https://"+os.getenv("INFERENCE_URL")
+            add_inference_url= "https://"+os.getenv("DB_API_URL")
             response = requests.post(add_inference_url, json=add_inferences)
 
             return {

--- a/automation/serverless_inference_deploy/push_aws_ecr.sh.sample
+++ b/automation/serverless_inference_deploy/push_aws_ecr.sh.sample
@@ -1,0 +1,5 @@
+#!/bin/sh
+aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin [ecr uri]
+docker build -t serverless-inference-deploy .
+docker tag serverless-inference-deploy:latest [ecr uri]/serverless-inference-deploy:latest
+docker push [ecr uri]/serverless-inference-deploy:latest

--- a/automation/serverless_inference_deploy/push_aws_ecr.sh.sample
+++ b/automation/serverless_inference_deploy/push_aws_ecr.sh.sample
@@ -1,5 +1,8 @@
 #!/bin/sh
-aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin [ecr uri]
+
+ECR_URI=""
+
+aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin $ECR_URI
 docker build -t serverless-inference-deploy .
-docker tag serverless-inference-deploy:latest [ecr uri]/serverless-inference-deploy:latest
-docker push [ecr uri]/serverless-inference-deploy:latest
+docker tag serverless-inference-deploy:latest $ECR_URI/serverless-inference-deploy:latest
+docker push $ECR_URI/serverless-inference-deploy:latest


### PR DESCRIPTION
endpoint url을 db에 등록하도록 변경함.
추론 db는 아래와 같음
```
{    
    "user": "",
    "name": "",
    "model": "",
    "type": "",
    "endpoint": ""
}
```
- user: user_uid
- name: endpoint name
- model: model_uid
- tpye: spot or serverless
- endpoint: endpoint url
---
- lambda handler 실행 시 없는 parameter가 존재할 경우 에러가 발생하므로 전체 파라미터를 받은 후 따로 get 하도록 변경
    - terraform apply 시 inference_uid는 필요 없으므로
- inference uid가 존재하면 destroy를 진행하도록 변경
    - destroy를 진행하면서 db에 등록한 endpoint url을 삭제
    - 삭제 시 inference uid는 콘솔에서 제공함
- inference uid가 없다면 create를 진행
    - endpoint를 생성 후 endpoint url을 db에 등록
- terraform.state를 s3에 저장하는 경로는 다음과 같음
    - "{user_uid}/{model_uid}/{type}/{endpoint_name}/terraform.state"