### PR TITLE
kubernetes cpu request limit 단위 표시 오류 수정 

### DIFF
--- a/automation/kubernetes_inference_deploy/main.py
+++ b/automation/kubernetes_inference_deploy/main.py
@@ -52,11 +52,11 @@ spec:
           value: {model_s3_url}
         resources:
             requests:
-                cpu: {int(ram_size/4096*1000)}M
+                cpu: {int(ram_size/4096*1000)}m
                 memory: {ram_size}M
                 nvidia.com/gpu: 1
             limits:
-                cpu: {int(ram_size/4096*1000)}M
+                cpu: {int(ram_size/4096*1000)}m
                 memory: {ram_size}M
                 nvidia.com/gpu: 1
       nodeSelector:


### PR DESCRIPTION
CPU의 milicores는 M이 아닌 m으로 표시됨.